### PR TITLE
added second test to currentLine so the answer isn't easily hardcoded, changed wording slightly on two tests.

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,7 +30,7 @@ describe('deli', () => {
   });
 
   describe('nowServing', () => {
-    it('returns the line is empty when no one is on line', () => {
+    it('returns "There is nobody waiting to be served!" when no one is on line', () => {
       expect(nowServing([])).toEqual("There is nobody waiting to be served!");
     });
 
@@ -41,7 +41,7 @@ describe('deli', () => {
     });
   });
 
-  describe('currentLine(line)', () => {
+  describe('currentLine', () => {
     it('returns "The line is currently empty." if no one is in line', () => {
       expect(currentLine([])).toEqual("The line is currently empty.");
     });
@@ -49,5 +49,10 @@ describe('deli', () => {
     it('says who is in line when there are people waiting', () => {
       expect(currentLine(["Bill", "Jane", "Ann"])).toEqual("The line is currently: 1. Bill, 2. Jane, 3. Ann");
     });
+ 
+    it('returns a different response programmatically given a different array of names', () => {
+      expect(currentLine(["Harry", "Sally", "Marie", "Jess"])).toEqual("The line is currently: 1. Harry, 2. Sally, 3. Marie, 4. Jess");
+    });
+
   });
 })


### PR DESCRIPTION
After a student hardcoded their solution to currentLine without realizing that was a mistake, I've added a second test with a different array to make it more difficult to do that.

To fully solve the hardcoding issue, I could make the array names randomly generate each time and/or use faker. I've currently avoided that to optimize for readability for new students (we're solving for accidental hardcoding based on misconception, not willful shameless greening), but glad to change if it's necessary.

Additionally, I've changed the title of the third describe so it doesn't stipulate what arguments the function takes, to be consistent with the styling of the earlier tests, and I've changed the description of the nowServing test for the empty array case so it explicitly states the return statement the function is looking for.

Glad to change any of these last two if they were done on design, figured I'd clean them up while I was messing with this. Let me know any feedback.